### PR TITLE
Feat: 롤페 상세 페이지 (주최자) 퍼블리싱 구현

### DIFF
--- a/app/(logoHeaderRoute)/rollpe/[rollpeId]/page.tsx
+++ b/app/(logoHeaderRoute)/rollpe/[rollpeId]/page.tsx
@@ -1,0 +1,140 @@
+"use client";
+import { COLORS } from "@/public/styles/colors";
+import Image from "next/image";
+import { useParams } from "next/navigation";
+import { useEffect } from "react";
+import styled from "styled-components";
+import DUMMY from "@/public/images/image/image_templete.png";
+import {
+  Button,
+  ButtonSecondary,
+} from "@/app/_components/ui/button/StyledButton";
+
+const RollpeDetailPage: React.FC = () => {
+  const rollpeId = useParams().rollpeId;
+
+  return (
+    <RollpeDetailPageWrapper>
+      <RollpeDetailPageContainer>
+        <div className={"title-wrapper"}>
+          <h1>제목영역 롤페 아이디: {rollpeId}</h1>
+        </div>
+
+        <div className={"preview-wrapper"}>
+          <div className={"preview-image-wrapper"}>
+            <Image src={DUMMY} alt={"미리보기 이미지"} layout="responsive" />
+          </div>
+          <p>롤페를 눌러 마음을 전달하세요!</p>
+        </div>
+
+        <div className={"writer-wrapper"}>
+          <h4>작성자(3/13)</h4>
+          <ul className={"writer-container"}>
+            <li>김텐가(TengaSuki)</li>
+            <li>김텐가(TengaSuki)</li>
+            <li>김텐가(TengaSuki)</li>
+          </ul>
+        </div>
+
+        <div className={"participant-button-wrapper"}>
+          <button className={"participant-list-open"}>참여자 목록 &gt;</button>
+        </div>
+
+        <div className={"menu-button-container"}>
+          <Button text={"공유하기"} route={""} />
+          <ButtonSecondary text={"수정하기"} route={""} />
+        </div>
+      </RollpeDetailPageContainer>
+    </RollpeDetailPageWrapper>
+  );
+};
+
+const RollpeDetailPageWrapper = styled.main`
+  padding: 5rem 1.25rem;
+  width: calc(100% - 2.5rem);
+  font-family: var(--font-hakgyoansim);
+  color: ${COLORS.ROLLPE_SECONDARY};
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+`;
+
+const RollpeDetailPageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+
+  & > .title-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    margin-bottom: 3.25rem;
+
+    font-size: 2rem;
+  }
+
+  & > .preview-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    width: 100%;
+
+    & > .preview-image-wrapper {
+      width: 100%;
+    }
+
+    & > p {
+      font-size: 1rem;
+    }
+  }
+
+  & > .writer-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    margin-top: 2.5rem;
+    width: 100%;
+
+    & > h4 {
+      font-size: 1.25rem;
+    }
+
+    & > .writer-container {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+
+      & > li {
+        font-size: 1rem;
+      }
+    }
+  }
+
+  & > .participant-button-wrapper {
+    display: flex;
+    margin-top: 2.5rem;
+    width: 100%;
+
+    & > .participant-list-open {
+      all: unset;
+      font-size: 1.25rem;
+      cursor: pointer;
+    }
+  }
+
+  & > .menu-button-container {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 2.5rem;
+    width: 100%;
+
+    & > button {
+      width: 48%;
+    }
+  }
+`;
+
+export default RollpeDetailPage;

--- a/app/(logoHeaderRoute)/rollpe/create/page.tsx
+++ b/app/(logoHeaderRoute)/rollpe/create/page.tsx
@@ -225,7 +225,7 @@ const RollpeCreatePage: React.FC = () => {
           </div>
         </div>
 
-        <Button text={"만들기"} router={""} />
+        <Button text={"만들기"} route={""} />
       </RollpeCreatePageContainer>
     </RollpeCreatePageWrapper>
   );

--- a/app/_components/ui/layouts/Header.tsx
+++ b/app/_components/ui/layouts/Header.tsx
@@ -75,7 +75,7 @@ export const HeaderMenuLogo: React.FC = () => {
   };
 
   return (
-    <LogoHeaderWRapper left={true}>
+    <LogoHeaderWrapper left={true}>
       <BackButton onClick={() => onClickBackHandler()}>
         <Image
           src={Back}
@@ -103,7 +103,7 @@ export const HeaderMenuLogo: React.FC = () => {
           alt={"메뉴 아이콘"}
         />
       </MenuButton>
-    </LogoHeaderWRapper>
+    </LogoHeaderWrapper>
   );
 };
 
@@ -118,14 +118,14 @@ export const HeaderLogo = () => {
     router.push("/main");
   };
   return (
-    <LogoHeaderWRapper left={true}>
+    <LogoHeaderWrapper left={true}>
       <BackButton onClick={() => onClickBackHandler()}>
         <Image
           src={Back}
           layout="responsive"
           width={28}
           height={28}
-          alt={"메뉴 아이콘"}
+          alt={"뒤로가기"}
         />
       </BackButton>
       <LogoButton onClick={() => onClickLogoHandler()}>
@@ -137,7 +137,8 @@ export const HeaderLogo = () => {
           alt={"홈으로"}
         />
       </LogoButton>
-    </LogoHeaderWRapper>
+      <div className={"dummy"}></div>
+    </LogoHeaderWrapper>
   );
 };
 
@@ -153,7 +154,7 @@ const HeaderWrapper = styled.header<{ left: boolean }>`
   background: transparent;
 `;
 
-const LogoHeaderWRapper = styled(HeaderWrapper)`
+const LogoHeaderWrapper = styled(HeaderWrapper)`
   align-items: center;
   justify-content: space-between;
 `;

--- a/app/_components/ui/modal/Modal.tsx
+++ b/app/_components/ui/modal/Modal.tsx
@@ -1,0 +1,5 @@
+"use client";
+import styled from "styled-components";
+import { COLORS } from "@/public/styles/colors";
+import Image from "next/image";
+


### PR DESCRIPTION
## Summary
- 롤페 상세 페이지 (주최자) 퍼블리싱 구현 완료
- 공유 및 수정 모달 구현중
- Redux에 저장되는 유저 정보를 토대로 해당 롤페의 주최자 ID와 유저 정보의 ID가 일치하면 조건부 렌더링으로 처리할 예정임.