### PR TITLE
Feat & Refactor: 로그인 후 메인페이지 '지금 뜨고 있는 롤페' 기능 구현

### DIFF
--- a/app/(defaultHeaderRoute)/main/_components/list/HotRollpeList.tsx
+++ b/app/(defaultHeaderRoute)/main/_components/list/HotRollpeList.tsx
@@ -25,10 +25,6 @@ const HotRollpeList: React.FC = () => {
     getList();
   }, []);
 
-  useEffect(() => {
-    console.log(hotRollpeList);
-  }, [hotRollpeList]);
-
   return (
     <ListContainer>
       {hotRollpeList &&

--- a/app/(defaultHeaderRoute)/main/_components/list/HotRollpeList.tsx
+++ b/app/(defaultHeaderRoute)/main/_components/list/HotRollpeList.tsx
@@ -1,0 +1,48 @@
+"use client";
+import { useTransition, useEffect, useState } from "react";
+import { hotList } from "@/app/api/main/hot-list/route";
+import MainRollpeCard from "@/app/_components/ui/card/main-rollpe-list/MainRollpeCard";
+import styled from "styled-components";
+import { MainRollpeCardProps } from "@/public/utils/types";
+
+const HotRollpeList: React.FC = () => {
+  const [isPending, startTransition] = useTransition();
+  const [hotRollpeList, setHotRollpeList] = useState<MainRollpeCardProps[]>([]);
+  const getList = () => {
+    startTransition(async () => {
+      try {
+        const result = await hotList().then((res) => {
+          setHotRollpeList(res.data);
+        });
+      } catch (error) {
+        console.error(error);
+        throw error;
+      }
+    });
+  };
+
+  useEffect(() => {
+    getList();
+  }, []);
+
+  useEffect(() => {
+    console.log(hotRollpeList);
+  }, [hotRollpeList]);
+
+  return (
+    <ListContainer>
+      {hotRollpeList &&
+        hotRollpeList.map((rollpe) => (
+          <MainRollpeCard key={rollpe.id} {...rollpe} />
+        ))}
+    </ListContainer>
+  );
+};
+
+const ListContainer = styled.ul`
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr 1fr;
+`;
+
+export default HotRollpeList;

--- a/app/(defaultHeaderRoute)/main/_components/styles/MainPageStyles.ts
+++ b/app/(defaultHeaderRoute)/main/_components/styles/MainPageStyles.ts
@@ -1,0 +1,88 @@
+"use client";
+import styled from "styled-components";
+import { COLORS } from "@/public/styles/colors";
+
+export const MainPageWrapper = styled.main`
+  width: 100%;
+  position: relative;
+`;
+
+export const MainPageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  width: 100%;
+
+  font-family: var(--font-hakgyoansim);
+`;
+
+export const DashboardWrapper = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2.5rem;
+
+  padding: 2.5rem 1.25rem 2.188rem 1.25rem;
+  width: calc(100% - 2.5rem);
+
+  & > .intro {
+    display: flex;
+    flex-direction: column;
+
+    width: 100%;
+
+    & > h2 {
+      color: ${COLORS.ROLLPE_SECONDARY};
+      font-size: 1.5rem;
+      font-style: normal;
+      font-weight: 400;
+      line-height: normal;
+      margin-bottom: 0.5rem;
+    }
+
+    & > p {
+      font-size: 1rem;
+      font-style: normal;
+      font-weight: 400;
+      line-height: normal;
+      margin-bottom: 0.25rem;
+    }
+  }
+
+  & > .button-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    width: 100%;
+  }
+`;
+
+export const RecentRollpeWrapper = styled.section`
+  width: 100%;
+
+  background: ${COLORS.ROLLPE_SECTION_BACKGROUND};
+
+  & > .contents {
+    display: flex;
+    flex-direction: column;
+    gap: 2.5rem;
+
+    padding: 2.5rem 1.25rem;
+    width: calc(100% - 2.5rem);
+
+    & > h2 {
+      font-size: 1.5rem;
+      font-style: normal;
+      font-weight: 400;
+      line-height: normal;
+    }
+
+    & > .list-container {
+      display: grid;
+      gap: 1rem;
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+`;

--- a/app/(defaultHeaderRoute)/main/page.tsx
+++ b/app/(defaultHeaderRoute)/main/page.tsx
@@ -1,13 +1,16 @@
-"use client";
+import {
+  MainPageWrapper,
+  MainPageContainer,
+  DashboardWrapper,
+  RecentRollpeWrapper,
+} from "./_components/styles/MainPageStyles";
 import {
   Button,
   ButtonSecondary,
 } from "@/app/_components/ui/button/StyledButton";
-import MainRollpeCard from "@/app/_components/ui/card/main-rollpe-list/MainRollpeCard";
-import { COLORS } from "@/public/styles/colors";
-import styled from "styled-components";
+import HotRollpeList from "./_components/list/HotRollpeList";
 
-const MainPage: React.FC = () => {
+const Main: React.FC = () => {
   return (
     <MainPageWrapper>
       <MainPageContainer>
@@ -27,15 +30,7 @@ const MainPage: React.FC = () => {
         <RecentRollpeWrapper>
           <div className={"contents"}>
             <h2>지금 뜨고 있는 롤페</h2>
-
-            <div className={"list-container"}>
-              <MainRollpeCard />
-              <MainRollpeCard />
-              <MainRollpeCard />
-              <MainRollpeCard />
-              <MainRollpeCard />
-              <MainRollpeCard />
-            </div>
+            <HotRollpeList />
           </div>
         </RecentRollpeWrapper>
       </MainPageContainer>
@@ -43,89 +38,4 @@ const MainPage: React.FC = () => {
   );
 };
 
-const MainPageWrapper = styled.main`
-  width: 100%;
-  position: relative;
-`;
-
-const MainPageContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-
-  width: 100%;
-
-  font-family: var(--font-hakgyoansim);
-`;
-
-const DashboardWrapper = styled.section`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2.5rem;
-
-  padding: 2.5rem 1.25rem 2.188rem 1.25rem;
-  width: calc(100% - 2.5rem);
-
-  & > .intro {
-    display: flex;
-    flex-direction: column;
-
-    width: 100%;
-
-    & > h2 {
-      color: ${COLORS.ROLLPE_SECONDARY};
-      font-size: 1.5rem;
-      font-style: normal;
-      font-weight: 400;
-      line-height: normal;
-      margin-bottom: 0.5rem;
-    }
-
-    & > p {
-      font-size: 1rem;
-      font-style: normal;
-      font-weight: 400;
-      line-height: normal;
-      margin-bottom: 0.25rem;
-    }
-  }
-
-  & > .button-wrapper {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-
-    width: 100%;
-  }
-`;
-
-const RecentRollpeWrapper = styled.section`
-  width: 100%;
-
-  background: ${COLORS.ROLLPE_SECTION_BACKGROUND};
-
-  & > .contents {
-    display: flex;
-    flex-direction: column;
-    gap: 2.5rem;
-
-    padding: 2.5rem 1.25rem;
-    width: calc(100% - 2.5rem);
-
-    & > h2 {
-      font-size: 1.5rem;
-      font-style: normal;
-      font-weight: 400;
-      line-height: normal;
-    }
-
-    & > .list-container {
-      display: grid;
-      gap: 1rem;
-      grid-template-columns: 1fr 1fr;
-    }
-  }
-`;
-
-export default MainPage;
+export default Main;

--- a/app/_components/ui/card/main-rollpe-list/MainRollpeCard.tsx
+++ b/app/_components/ui/card/main-rollpe-list/MainRollpeCard.tsx
@@ -2,31 +2,49 @@
 import styled from "styled-components";
 import { COLORS } from "@/public/styles/colors";
 import Image from "next/image";
+import { MainRollpeCardProps } from "@/public/utils/types";
 
-const MainRollpeCard: React.FC = () => {
+const MainRollpeCard: React.FC<MainRollpeCardProps> = (
+  data: MainRollpeCardProps
+) => {
+  const {
+    id,
+    title,
+    viewStat,
+    receivingStat,
+    receivingDate,
+    hostName,
+    code,
+    theme,
+  } = data;
+
   return (
     <CardWrapper>
-      <div className={"card-image"}>
-        <Badge>
-          <p>D-30</p>
-        </Badge>
+      <CardContainer>
+        <div className={"card-image"}>
+          <Badge>
+            <p>D-30</p>
+          </Badge>
 
-        <Image
-          src={"/images/image/image_dummy_cake.png"}
-          width={50}
-          height={46}
-          alt={""}
-        />
-      </div>
-      <div className={"card-contents"}>
-        <h3 className={"card-title"}>롤페 제목</h3>
-        <p className={"card-user"}>김테스트1</p>
-      </div>
+          <Image
+            src={"/images/image/image_dummy_cake.png"}
+            width={50}
+            height={46}
+            alt={""}
+          />
+        </div>
+        <div className={"card-contents"}>
+          <h3 className={"card-title"}>{title}</h3>
+          <p className={"card-user"}>{hostName}</p>
+        </div>
+      </CardContainer>
     </CardWrapper>
   );
 };
 
-const CardWrapper = styled.button`
+const CardWrapper = styled.li``;
+
+const CardContainer = styled.button`
   all: unset;
 
   display: flex;

--- a/app/api/main/hot-list/route.ts
+++ b/app/api/main/hot-list/route.ts
@@ -1,0 +1,17 @@
+"use server";
+
+import axios from "axios";
+
+export const hotList = async () => {
+  try {
+    const response = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/paper/user?type=hot`);
+
+    if (response.status === 200) {
+      return response.data;
+    }
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+
+}

--- a/public/utils/types.ts
+++ b/public/utils/types.ts
@@ -13,3 +13,15 @@ export interface RollpeListProps {
   rollpeList: RollpeListItemProps[];
   resultText: string;
 }
+
+
+export interface MainRollpeCardProps {
+  id: number;
+  title: string;
+  viewStat: boolean;
+  receivingStat: number;
+  receivingDate: string;
+  hostName: string;
+  code: string;
+  theme: any[];
+}


### PR DESCRIPTION
## Summary
- 로그인 후 표출되는 메인페이지의 '지금 뜨고 있는 롤페' 섹션의 API 연동 및 리스트 표출
- 기존 단일 button 엘리먼트로로 사용되던 ```MainRollpeCard``` 컴포넌트를 리스트 형식에 맞춰 li 엘리먼트로 수정
- 기존 클라이언트 컴포넌트로 작성되어 있던 ```main/page.tsx```를 서버 컴포넌트로 리팩토링
  - ```HotRollpeList``` : 지금 뜨고 있는 롤페 리스트 호출 및 렌더링을 담당하는 클라이언트 컴포넌트
  - 기존 main/page.tsx 내 styled-components를 main/_components/styles 하위에서 export하여 사용하도록 수정 